### PR TITLE
remove usage of `socket.SocketType`.

### DIFF
--- a/recipes/core/tcp.md
+++ b/recipes/core/tcp.md
@@ -50,7 +50,7 @@ def run_server(
     send_buf_size: Optional[int] = None,
     accept_queue_size: Optional[int] = None,
 ):
-    sock: socket.SocketType = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
     # Reuse address
     #

--- a/recipes/core/type_hint_for_socket.md
+++ b/recipes/core/type_hint_for_socket.md
@@ -5,11 +5,18 @@
 ```python
 import socket
 
-sock: socket.SocketType = socket.socket(...)
+# Removed usage of `socket.SocketType`
+# `SocketType` is an alias for the private `_socket.socket` class, a superclass of `socket.socket`.
+# It is better to just always use `socket.socket` in types.
+# See https://bugs.python.org/issue44261 and python/typeshed#5545 for some context.
+#   See https://github.com/python/typeshed/pull/5545
+#   See https://github.com/agronholm/anyio/pull/302
+sock: socket.socket = socket.socket(...)  # not socket.SocketType
 socket_type: socket.SocketKind = socket.SOCK_STREAM  # or `socket.SOCK_DGRAM`
 address_family: socket.AddressFamily = socket.AF_INET  # or `socket.AF_INET6`
 ```
 
 ## References
 
-More details to see [Type Hint on Python Handbook](https://leven-cn.github.io/python-handbook/recipes/core/type_hint).
+- More details to see [Type Hint on Python Handbook](https://leven-cn.github.io/python-handbook/recipes/core/type_hint).
+- [Removed usage of `socket.SocketType`](https://github.com/python/typeshed/pull/5545)


### PR DESCRIPTION
See https://github.com/agronholm/anyio/pull/302#issue-906803380:

> `SocketType` is an alias for the private `_socket.socket` class, a superclass of `socket.socket`.
> It is better to just always use `socket.socket` in types.

See https://bugs.python.org/issue44261 and https://github.com/python/typeshed/pull/5545 for some context.